### PR TITLE
カレンダー削除機能の導入

### DIFF
--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -16,6 +16,7 @@ class CalendarsController < ApplicationController
       @event = UserEvent.find(params[:id])
       @events = UserEvent.where(user_id: current_user.id).where(day: @event.start_time.day).order('start_time ASC')
     elsif team_signed_in?
+      @event = TeamEvent.find(params[:id])
       @events = TeamEvent.where(team_id: current_team.id).where(day: @event.start_time.day).order('start_time ASC')
     end
   end
@@ -85,7 +86,7 @@ class CalendarsController < ApplicationController
   def destroy
     if user_signed_in?
       @event = UserEvent.find(params[:id])
-      if event.destroy
+      if @event.destroy
         redirect_to calendars_path
       else
         flash[:alert]="削除に失敗しました"

--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -16,7 +16,7 @@ class CalendarsController < ApplicationController
       @event = UserEvent.find(params[:id])
       @events = UserEvent.where(user_id: current_user.id).where(day: @event.start_time.day).order('start_time ASC')
     elsif team_signed_in?
-      @events = TeamEvent.where(team_id: current_team.id)
+      @events = TeamEvent.where(team_id: current_team.id).where(day: @event.start_time.day).order('start_time ASC')
     end
   end
 
@@ -83,9 +83,25 @@ class CalendarsController < ApplicationController
   end
 
   def destroy
-    event = UserEvent.find(params[:id])
-    event.destroy
-    redirect_to calendars_path
+    if user_signed_in?
+      @event = UserEvent.find(params[:id])
+      if event.destroy
+        redirect_to calendars_path
+      else
+        flash[:alert]="削除に失敗しました"
+        @events = UserEvent.where(user_id: current_user.id).where(day: @event.start_time.day).order('start_time ASC')
+        render 'calendars/show'
+      end
+    elsif team_signed_in?
+      @event = TeamEvent.find(params[:id])
+      if @event.destroy
+        redirect_to calendars_path
+      else
+        flash[:alert]="削除に失敗しました"
+        @events = TeamEvent.where(team_id: current_user.id).where(day: @event.start_time.day).order('start_time ASC')
+        render 'calendars/show'
+      end
+    end
   end
 
   private

--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -16,7 +16,7 @@ class CalendarsController < ApplicationController
       @event = UserEvent.find(params[:id])
       @events = UserEvent.where(user_id: current_user.id).where(day: @event.start_time.day).order('start_time ASC')
     elsif team_signed_in?
-      @events = TeamEvent.where(team_id: current_team.id).where(day: @event.start_time.day).order('start_time ASC')
+      @events = TeamEvent.where(team_id: current_team.id)
     end
   end
 
@@ -83,25 +83,9 @@ class CalendarsController < ApplicationController
   end
 
   def destroy
-    if user_signed_in?
-      @event = UserEvent.find(params[:id])
-      if event.destroy
-        redirect_to calendars_path
-      else
-        flash[:alert]="削除に失敗しました"
-        @events = UserEvent.where(user_id: current_user.id).where(day: @event.start_time.day).order('start_time ASC')
-        render 'calendars/show'
-      end
-    elsif team_signed_in?
-      @event = TeamEvent.find(params[:id])
-      if @event.destroy
-        redirect_to calendars_path
-      else
-        flash[:alert]="削除に失敗しました"
-        @events = TeamEvent.where(team_id: current_user.id).where(day: @event.start_time.day).order('start_time ASC')
-        render 'calendars/show'
-      end
-    end
+    event = UserEvent.find(params[:id])
+    event.destroy
+    redirect_to calendars_path
   end
 
   private

--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -89,7 +89,7 @@ class CalendarsController < ApplicationController
       if @event.destroy
         redirect_to calendars_path
       else
-        flash[:alert]="削除に失敗しました"
+        flash[:alert] = '削除に失敗しました'
         @events = UserEvent.where(user_id: current_user.id).where(day: @event.start_time.day).order('start_time ASC')
         render 'calendars/show'
       end
@@ -98,7 +98,7 @@ class CalendarsController < ApplicationController
       if @event.destroy
         redirect_to calendars_path
       else
-        flash[:alert]="削除に失敗しました"
+        flash[:alert] = '削除に失敗しました'
         @events = TeamEvent.where(team_id: current_user.id).where(day: @event.start_time.day).order('start_time ASC')
         render 'calendars/show'
       end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -40,6 +40,13 @@ class SamplesController < ApplicationController
   end
 
   def destroy
+    @event = Sample.find(params[:id])
+    if @event.destroy
+      redirect_to samples_path
+    else
+      flash[:alert]
+      render 'samples/show'
+    end
   end
 
   private

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -44,7 +44,8 @@ class SamplesController < ApplicationController
     if @event.destroy
       redirect_to samples_path
     else
-      flash[:alert]
+      flash[:alert]="削除に失敗しました"
+      @events = Sample.where(day: @event.start_time.day).order('start_time ASC')
       render 'samples/show'
     end
   end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -44,8 +44,7 @@ class SamplesController < ApplicationController
     if @event.destroy
       redirect_to samples_path
     else
-      flash[:alert]="削除に失敗しました"
-      @events = Sample.where(day: @event.start_time.day).order('start_time ASC')
+      flash[:alert]
       render 'samples/show'
     end
   end

--- a/app/controllers/samples_controller.rb
+++ b/app/controllers/samples_controller.rb
@@ -44,7 +44,7 @@ class SamplesController < ApplicationController
     if @event.destroy
       redirect_to samples_path
     else
-      flash[:alert]="削除に失敗しました"
+      flash[:alert] = '削除に失敗しました'
       @events = Sample.where(day: @event.start_time.day).order('start_time ASC')
       render 'samples/show'
     end

--- a/app/views/calendars/new.html.erb
+++ b/app/views/calendars/new.html.erb
@@ -65,7 +65,7 @@
       end_month.value = start_month.value
       end_day.value = start_day.value
     }
-    setInterval(input, 300);
+    setInterval(input, 200);
   </script>
 <% end %>
 

--- a/app/views/calendars/show.html.erb
+++ b/app/views/calendars/show.html.erb
@@ -13,7 +13,7 @@
           <%= link_to "編集する", edit_calendar_path(event) %>
         </div>
         <div class="btn btn-danger">
-          <%= link_to "削除する", sample_path(event), method: :delete %>
+          <%= link_to "削除する", calendar_path(event), method: :delete %>
         </div>
       </div>
     <% end %>

--- a/app/views/calendars/show.html.erb
+++ b/app/views/calendars/show.html.erb
@@ -12,6 +12,9 @@
         <div class="btn btn-warning">
           <%= link_to "編集する", edit_calendar_path(event) %>
         </div>
+        <div class="btn btn-danger">
+          <%= link_to "削除する", sample_path(event), method: :delete %>
+        </div>
       </div>
     <% end %>
 </div>

--- a/app/views/samples/new.html.erb
+++ b/app/views/samples/new.html.erb
@@ -62,5 +62,5 @@
     end_month.value = start_month.value
     end_day.value = start_day.value
   }
-  setInterval(input, 1000);
+  setInterval(input, 200);
 </script>

--- a/app/views/samples/show.html.erb
+++ b/app/views/samples/show.html.erb
@@ -13,6 +13,9 @@
         <div class="btn btn-warning">
           <%= link_to "編集する", edit_sample_path(event) %>
         </div>
+        <div class="btn btn-danger">
+          <%= link_to "削除する", sample_path(event), method: :delete %>
+        </div>
       </div>
     <% end %>
 </div>

--- a/spec/system/samples_spec.rb
+++ b/spec/system/samples_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe '予定削除機能', type: :system do
       # タイトルの下には編集するためのリンクがあることを確認する
       expect(page).to have_link('削除する')
       # 削除するボタンをクリックすると、Sampleモデルのカウント数が1減ることを確認する
-      expect{ click_on("削除する") }.to change { Sample.count }.by(-1)
+      expect { click_on('削除する') }.to change { Sample.count }.by(-1)
       # カレンダー画面に遷移していることを確認する
       expect(current_path).to eq samples_path
       # カレンダー画面には削除した内容が表示されていないことを確認する

--- a/spec/system/samples_spec.rb
+++ b/spec/system/samples_spec.rb
@@ -162,3 +162,43 @@ RSpec.describe '予定編集機能', type: :system do
     end
   end
 end
+
+RSpec.describe '予定削除機能', type: :system do
+  before do
+    @sample = FactoryBot.build(:sample)
+  end
+
+  context '予定を削除できるとき' do
+    it '予定を作成したのち、詳細画面から予定を削除することができる' do
+      visit root_path
+      # カレンダーのリンクが存在することを確認
+      expect(page).to have_content('カレンダー')
+      # 予定を作成する
+      sample_create(@sample)
+      # カレンダー画面にあるタイトルをクリックする
+      click_on(@sample.title.to_s)
+      # 一日の予定一覧が表示されていることを確認する
+      expect(page).to have_content('一日の予定一覧')
+      # 一覧画面にはタイトルが表示されていることを確認する
+      expect(page).to have_content(@sample.title)
+      # タイトルの下には編集するためのリンクがあることを確認する
+      expect(page).to have_link('削除する')
+      # 削除するボタンをクリックすると、Sampleモデルのカウント数が1減ることを確認する
+      expect{ click_on("削除する") }.to change { Sample.count }.by(-1)
+      # カレンダー画面に遷移していることを確認する
+      expect(current_path).to eq samples_path
+      # カレンダー画面には削除した内容が表示されていないことを確認する
+      expect(page).to have_no_content(@sample.title)
+    end
+  end
+
+  context '予定を削除できないとき' do
+    it '予定を作成していない場合' do
+      visit root_path
+      # カレンダー画面に遷移していることを確認
+      expect(current_path).to eq(root_path)
+      # カレンダー画面には予定が記載されていないことを確認する
+      expect(page).to have_no_content(@sample.title)
+    end
+  end
+end

--- a/spec/system/team_events_spec.rb
+++ b/spec/system/team_events_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe '予定削除機能', type: :system do
       # タイトルの下には編集するためのリンクがあることを確認する
       expect(page).to have_link('削除する')
       # 削除するボタンをクリックすると、TeamEventモデルのカウント数が1減ることを確認する
-      expect{ click_on("削除する") }.to change { TeamEvent.count }.by(-1)
+      expect { click_on('削除する') }.to change { TeamEvent.count }.by(-1)
       # カレンダー画面に遷移していることを確認する
       expect(current_path).to eq calendars_path
       # カレンダー画面には削除した内容が表示されていないことを確認する
@@ -229,7 +229,7 @@ RSpec.describe '予定削除機能', type: :system do
       # カレンダー画面に遷移せずログイン画面に戻されることを確認する
       expect(current_path).to eq new_user_session_path
       # 戻されたときにエラーメッセージが表示されることを確認する
-      expect(page).to have_content("ログインしてください")
+      expect(page).to have_content('ログインしてください')
     end
   end
 end

--- a/spec/system/team_events_spec.rb
+++ b/spec/system/team_events_spec.rb
@@ -182,3 +182,54 @@ RSpec.describe '予定編集機能', type: :system do
     end
   end
 end
+
+RSpec.describe '予定削除機能', type: :system do
+  before do
+    @team = FactoryBot.create(:team)
+    @team_event = FactoryBot.build(:team_event)
+  end
+
+  context '予定を削除できるとき' do
+    it '予定を作成したのち、詳細画面から予定を削除することができる' do
+      # ログインする
+      team_sign_in(@team)
+      # カレンダーのリンクが存在することを確認
+      expect(page).to have_link('カレンダー')
+      # 予定を作成する
+      team_calendar(@team_event)
+      # カレンダー画面にあるタイトルをクリックする
+      click_on(@team_event.title.to_s)
+      # 一日の予定一覧が表示されていることを確認する
+      expect(page).to have_content('一日の予定一覧')
+      # 一覧画面にはタイトルが表示されていることを確認する
+      expect(page).to have_content(@team_event.title)
+      # タイトルの下には編集するためのリンクがあることを確認する
+      expect(page).to have_link('削除する')
+      # 削除するボタンをクリックすると、TeamEventモデルのカウント数が1減ることを確認する
+      expect{ click_on("削除する") }.to change { TeamEvent.count }.by(-1)
+      # カレンダー画面に遷移していることを確認する
+      expect(current_path).to eq calendars_path
+      # カレンダー画面には削除した内容が表示されていないことを確認する
+      expect(page).to have_no_content(@team_event.title)
+    end
+  end
+
+  context '予定を削除できないとき' do
+    it 'ログインをしたのみで、予定を作成していない場合' do
+      # ログインする
+      team_sign_in(@team)
+      # カレンダー画面に遷移していることを確認
+      expect(current_path).to eq(calendars_path)
+      # カレンダー画面には予定が記載されていないことを確認する
+      expect(page).to have_no_content(@team_event.title)
+    end
+
+    it 'ログインをしていない場合' do
+      visit calendars_path
+      # カレンダー画面に遷移せずログイン画面に戻されることを確認する
+      expect(current_path).to eq new_user_session_path
+      # 戻されたときにエラーメッセージが表示されることを確認する
+      expect(page).to have_content("ログインしてください")
+    end
+  end
+end

--- a/spec/system/user_events_spec.rb
+++ b/spec/system/user_events_spec.rb
@@ -205,7 +205,7 @@ RSpec.describe '予定削除機能', type: :system do
       # タイトルの下には編集するためのリンクがあることを確認する
       expect(page).to have_link('削除する')
       # 削除するボタンをクリックすると、UserEventモデルのカウント数が1減ることを確認する
-      expect{ click_on("削除する") }.to change { UserEvent.count }.by(-1)
+      expect { click_on('削除する') }.to change { UserEvent.count }.by(-1)
       # カレンダー画面に遷移していることを確認する
       expect(current_path).to eq calendars_path
       # カレンダー画面には削除した内容が表示されていないことを確認する
@@ -228,7 +228,7 @@ RSpec.describe '予定削除機能', type: :system do
       # カレンダー画面に遷移せずログイン画面に戻されることを確認する
       expect(current_path).to eq new_user_session_path
       # 戻されたときにエラーメッセージが表示されることを確認する
-      expect(page).to have_content("ログインしてください")
+      expect(page).to have_content('ログインしてください')
     end
   end
 end

--- a/spec/system/user_events_spec.rb
+++ b/spec/system/user_events_spec.rb
@@ -181,3 +181,54 @@ RSpec.describe '予定編集機能', type: :system do
     end
   end
 end
+
+RSpec.describe '予定削除機能', type: :system do
+  before do
+    @user = FactoryBot.create(:user)
+    @user_event = FactoryBot.build(:user_event)
+  end
+
+  context '予定を削除できるとき' do
+    it '予定を作成したのち、詳細画面から予定を削除することができる' do
+      # ログインする
+      user_sign_in(@user)
+      # カレンダーのリンクが存在することを確認
+      expect(page).to have_link('カレンダー')
+      # 予定を作成する
+      user_calendar(@user_event)
+      # カレンダー画面にあるタイトルをクリックする
+      click_on(@user_event.title.to_s)
+      # 一日の予定一覧が表示されていることを確認する
+      expect(page).to have_content('一日の予定一覧')
+      # 一覧画面にはタイトルが表示されていることを確認する
+      expect(page).to have_content(@user_event.title)
+      # タイトルの下には編集するためのリンクがあることを確認する
+      expect(page).to have_link('削除する')
+      # 削除するボタンをクリックすると、UserEventモデルのカウント数が1減ることを確認する
+      expect{ click_on("削除する") }.to change { UserEvent.count }.by(-1)
+      # カレンダー画面に遷移していることを確認する
+      expect(current_path).to eq calendars_path
+      # カレンダー画面には削除した内容が表示されていないことを確認する
+      expect(page).to have_no_content(@user_event.title)
+    end
+  end
+
+  context '予定を削除できないとき' do
+    it 'ログインをしたのみで、予定を作成していない場合' do
+      # ログインする
+      user_sign_in(@user)
+      # カレンダー画面に遷移していることを確認
+      expect(current_path).to eq(calendars_path)
+      # カレンダー画面には予定が記載されていないことを確認する
+      expect(page).to have_no_content(@user_event.title)
+    end
+
+    it 'ログインをしていない場合' do
+      visit calendars_path
+      # カレンダー画面に遷移せずログイン画面に戻されることを確認する
+      expect(current_path).to eq new_user_session_path
+      # 戻されたときにエラーメッセージが表示されることを確認する
+      expect(page).to have_content("ログインしてください")
+    end
+  end
+end


### PR DESCRIPTION
# What

カレンダーの削除機能の導入

# Why

削除機能を導入することで、ユーザーが誤って予定を作成してしまった場合や、
終了して必要のなくなった予定などを削除するため。